### PR TITLE
Status of a course request is set to false when created

### DIFF
--- a/TimeTrackerV2/Angular/src/app/courses/courses.component.ts
+++ b/TimeTrackerV2/Angular/src/app/courses/courses.component.ts
@@ -105,7 +105,7 @@ export class CoursesComponent implements OnInit {
         instructorID: cId.instructorID,
         isActive: true,
         reviewerID: null,
-        status: true,
+        status: false,
 
       }
 


### PR DESCRIPTION
So that when a request is denied, no further action needs to be made